### PR TITLE
Update to latest version of jslint.js

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>1d8c1f8f74</upstream.version>
-        <upstream.commit>1d8c1f8f7410b505ccbb039a74025cd75a926ce3</upstream.commit>
+        <upstream.version>c657984cd7</upstream.version>
+        <upstream.commit>c657984cd7dfc17277feadb86d1de24c664f944a</upstream.commit>
         <upstream.url>https://raw.github.com/douglascrockford/JSLint/${upstream.commit}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
The pull request uses latest SHA1 commit.
I could change the versioning strategy of this webjar, but an input is required regarding this issue: https://github.com/webjars/jshint/issues/3
